### PR TITLE
docs(readme): change in tokio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features which can be enabled / disabled during library build.
 | `tokio`      | off     | Enables crate to be used with [tokio](https://tokio.rs) runtime and libraries |
 
 Enabling `tokio` feature allows user to use `tokio::fs::File` and makes `AsyncReader` (`AsyncWriter`) 
-to be based on `tokio::io::AsyncRead` (`tokio::io::AsyncWrite`). Currently this crate depends on tokio version 0.2.
+to be based on `tokio::io::AsyncRead` (`tokio::io::AsyncWrite`). Currently this crate depends on tokio version 1.12.
 
 Without `tokio` feature, this crate depends only on `futures` crate and reader (writer) are based on traits `futures::io::AsyncRead` (`futures::io::AsyncWrite`), what allows user to use `async_std::fs::File`.
 


### PR DESCRIPTION
Hello,
At beginning I was amazed that you are using tokio 0.2, but found that is just a typo/historical. 

Regards