### PR TITLE
Made deserialization inner Error public

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.56.0
+          - 1.60.0
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.2.5"
 authors = ["gwierzchowski <gwierzchowski@wp.pl>"]
 description = "CSV parsing for async."
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 keywords = ["csv", "comma", "parser", "async"]
 categories = ["asynchronous", "encoding", "parser-implementations"]
 repository = "https://github.com/gwierzchowski/csv-async"
@@ -37,6 +37,6 @@ tokio-stream = { version = "0.1", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"]}
-indoc = "1"
+indoc = "2"
 serde = { version = "1", features = ["derive"] }
 tokio1 = { package = "tokio", version = "1.20", features = ["rt", "rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/crates/d/csv-async.svg)](https://crates.io/crates/csv-async)
 [![](https://img.shields.io/crates/dv/csv-async.svg)](https://crates.io/crates/csv-async)
 [![Documentation](https://docs.rs/csv-async/badge.svg)](https://docs.rs/csv-async)
-[![Version](https://img.shields.io/badge/rustc-1.56+-ab6000.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+[![Version](https://img.shields.io/badge/rustc-1.60+-ab6000.svg)](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html)
 
 [![build status](https://github.com/gwierzchowski/csv-async/workflows/Linux/badge.svg?branch=master&event=push)](https://github.com/gwierzchowski/csv-async/actions?query=workflow%3ALinux)
 [![build status](https://github.com/gwierzchowski/csv-async/workflows/Windows/badge.svg?branch=master&event=push)](https://github.com/gwierzchowski/csv-async/actions?query=workflow%3AWindows)

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -699,7 +699,7 @@ impl StdError for DeserializeError {
 impl fmt::Display for DeserializeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(field) = self.field {
-            write!(f, "field {}: {}", field, self.kind)
+            write!(f, "field {}: {}", field + 1, self.kind)
         } else {
             write!(f, "{}", self.kind)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -159,25 +159,23 @@ impl fmt::Display for Error {
         match *self.0 {
             ErrorKind::Io(ref err) => err.fmt(f),
             ErrorKind::Utf8 { pos: None, ref err } => {
-                write!(f, "CSV parse error: field {}: {}", err.field(), err)
+                write!(f, "CSV parse error: field {}: {err}", err.field() + 1)
             }
             ErrorKind::Utf8 { pos: Some(ref pos), ref err } => write!(
                 f,
                 "CSV parse error: record {} \
-                 (line {}, field: {}, byte: {}): {}",
+                 (line {}, field: {}, byte: {}): {err}",
                 pos.record(),
                 pos.line(),
-                err.field(),
+                err.field() + 1,
                 pos.byte(),
-                err
             ),
             ErrorKind::UnequalLengths { pos: None, expected_len, len } => {
                 write!(
                     f,
                     "CSV error: \
-                     found record with {} fields, but the previous record \
-                     has {} fields",
-                    len, expected_len
+                     found record with {len} fields, but the previous record \
+                     has {expected_len} fields"
                 )
             }
             ErrorKind::UnequalLengths {
@@ -187,13 +185,11 @@ impl fmt::Display for Error {
             } => write!(
                 f,
                 "CSV error: record {} (line: {}, byte: {}): \
-                 found record with {} fields, but the previous record \
-                 has {} fields",
+                 found record with {len} fields, but the previous record \
+                 has {expected_len} fields",
                 pos.record(),
                 pos.line(),
                 pos.byte(),
-                len,
-                expected_len
             ),
             ErrorKind::Seek => write!(
                 f,
@@ -203,11 +199,11 @@ impl fmt::Display for Error {
             ),
             #[cfg(feature = "with_serde")]
             ErrorKind::Serialize(ref msg) => {
-                write!(f, "CSV serialize error: {}", msg)
+                write!(f, "CSV serialize error: {msg}")
             }
             #[cfg(feature = "with_serde")]
             ErrorKind::Deserialize { pos: None, ref err } => {
-                write!(f, "CSV deserialize error: {}", err)
+                write!(f, "CSV deserialize error: {err}")
             }
             #[cfg(feature = "with_serde")]
             ErrorKind::Deserialize {
@@ -216,11 +212,10 @@ impl fmt::Display for Error {
             } => write!(
                 f,
                 "CSV deserialize error: record {} \
-                 (line {}, byte: {}): {}",
+                 (line {}, byte: {}): {err}",
                 pos.record(),
                 pos.line(),
                 pos.byte(),
-                err
             ),
             _ => unreachable!(),
         }
@@ -304,7 +299,7 @@ impl fmt::Display for Utf8Error {
         write!(
             f,
             "invalid utf-8: invalid UTF-8 in field {} near byte index {}",
-            self.field, self.valid_up_to
+            self.field + 1, self.valid_up_to
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,9 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-csv-async = "1.1"
+csv-async = "1.2"
 # or
-# csv-async = {version = "1.1", features = ["tokio"]}
+# csv-async = {version = "1.2", features = ["tokio"]}
 ```
 
 # Examples
@@ -452,6 +452,7 @@ cfg_if::cfg_if! {
 if #[cfg(feature = "with_serde")] {
     mod deserializer;
     mod serializer;
+    pub use deserializer::{DeserializeError, DeserializeErrorKind};
 }}
 
 mod async_readers;

--- a/tests/data/cities_incomplete_row.csv
+++ b/tests/data/cities_incomplete_row.csv
@@ -1,0 +1,8 @@
+city,region,country,population
+Southborough,MA,United States,9686
+Northbridge,MA
+Marlborough,MA,United States,38334
+Boston,MA,United States,152227
+Springfield,MO,United States,150443
+Trenton,NJ,United States,14976
+Plymouth,NH,United States,42605

--- a/tests/data/cities_non_int.csv
+++ b/tests/data/cities_non_int.csv
@@ -1,0 +1,8 @@
+city,region,country,population
+Southborough,MA,United States,9686
+Northbridge,MA,United States,14061
+Marlborough,MA,United States,xxxxx
+Boston,MA,United States,152227
+Springfield,MO,United States,150443
+Trenton,NJ,United States,14976
+Plymouth,NH,United States,42605

--- a/tests/data/cities_ok.csv
+++ b/tests/data/cities_ok.csv
@@ -1,0 +1,8 @@
+city,region,country,population
+Southborough,MA,United States,9686
+Northbridge,MA,United States,14061
+Marlborough,MA,United States,38334
+Boston,MA,United States,152227
+Springfield,MO,United States,150443
+Trenton,NJ,United States,14976
+Plymouth,NH,United States,42605

--- a/tests/data/cities_pl_win1250.csv
+++ b/tests/data/cities_pl_win1250.csv
@@ -1,0 +1,8 @@
+miasto,region,kraj,populacja
+Gdañsk,PM,Polska,582205
+Grudzi¹dz,KP,Polska,92894
+Kraków,MP,Polska,802800
+Kielce,SK,Polska,192468
+Nowy S¹cz,MP,Polska,83558
+Szczebrzeszyn,LB,Polska,4964
+£ódŸ,£D,Polska,664860

--- a/tests/helpers/helpers_async_std.rs
+++ b/tests/helpers/helpers_async_std.rs
@@ -1,0 +1,20 @@
+#![allow(dead_code)]
+pub use async_std::test;
+use async_std::fs::File;
+pub use futures::stream::StreamExt;
+
+pub type Reader = csv_async::AsyncReader<File>;
+#[cfg(feature = "with_serde")]
+pub type Deserializer = csv_async::AsyncDeserializer<File>;
+
+pub async fn get_reader(path: &str) -> async_std::io::Result<Reader> {
+    Ok(csv_async::AsyncReader::from_reader(File::open(path).await?))
+}
+
+#[cfg(feature = "with_serde")]
+pub async fn get_deserializer(path: &str) -> async_std::io::Result<Deserializer> {
+    Ok(
+        csv_async::AsyncReaderBuilder::new()
+            .create_deserializer(File::open(path).await?)
+    )
+}

--- a/tests/helpers/helpers_tokio.rs
+++ b/tests/helpers/helpers_tokio.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+pub use tokio1 as tokio;
+pub use tokio::test;
+use tokio::fs::File;
+pub use tokio_stream::StreamExt;
+
+pub type Reader = csv_async::AsyncReader<File>;
+#[cfg(feature = "with_serde")]
+pub type Deserializer = csv_async::AsyncDeserializer<File>;
+
+pub async fn get_reader(path: &str) -> async_std::io::Result<Reader> {
+    Ok(
+        csv_async::AsyncReader::from_reader(
+        File::open(path).await?
+    ))
+}
+
+#[cfg(feature = "with_serde")]
+pub async fn get_deserializer(path: &str) -> async_std::io::Result<Deserializer> {
+    Ok(
+        csv_async::AsyncReaderBuilder::new()
+            .create_deserializer(File::open(path).await?)
+    )
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,58 @@
+#[cfg(not(feature = "tokio"))]
+mod helpers_async_std;
+#[cfg(feature = "tokio")]
+mod helpers_tokio;
+
+#[cfg(not(feature = "tokio"))]
+pub use helpers_async_std::*;
+#[cfg(feature = "tokio")]
+pub use helpers_tokio::*;
+
+#[allow(dead_code)]
+pub fn custom_error_message(err: &csv_async::Error) -> String {
+    match err.kind() {
+        csv_async::ErrorKind::Io(e) => {
+            format!("IO Error: {e}")
+        },
+        csv_async::ErrorKind::Seek => {
+            String::from("Seek error")
+        },
+        csv_async::ErrorKind::UnequalLengths { pos, expected_len, len } => {
+            format!("Unequal lengths: position = {pos:?}, expected_len = {expected_len}, len = {len}")
+        },
+        csv_async::ErrorKind::Utf8 { pos, err } => {
+            format!("Invalid UTF8: position = {pos:?}, err = {err}")
+        },
+        #[cfg(feature = "with_serde")]
+        csv_async::ErrorKind::Serialize(msg) => {
+            format!("Serialize error: {msg}")
+        },
+        #[cfg(feature = "with_serde")]
+        csv_async::ErrorKind::Deserialize { pos, err } => {
+            let field = err.field();
+            let msg = match err.kind() {
+                csv_async::DeserializeErrorKind::InvalidUtf8(e) => {
+                    format!("Invalid UTF8: {e}")
+                },
+                csv_async::DeserializeErrorKind::Message(msg) => msg.clone(),
+                csv_async::DeserializeErrorKind::ParseBool(e) => {
+                    format!("Error parsing boolean: {e}")
+                }
+                csv_async::DeserializeErrorKind::ParseFloat(e) => {
+                    format!("Error parsing float: {e}")
+                }
+                csv_async::DeserializeErrorKind::ParseInt(e) => {
+                    format!("Error parsing integer: {e}")
+                }
+                csv_async::DeserializeErrorKind::UnexpectedEndOfRow => {
+                    String::from("Row has too few fields")
+                }
+                csv_async::DeserializeErrorKind::Unsupported(e) => {
+                    format!("Unsupported type: {e}")
+                }
+            };
+            format!("Deserialize error: position = {pos:?}, field = {field:?}: {msg}")
+        },
+        _ => String::from("Other error")
+    }
+}

--- a/tests/read_records.rs
+++ b/tests/read_records.rs
@@ -1,0 +1,70 @@
+mod helpers;
+use helpers::*;
+
+#[helpers::test]
+async fn read_records_ok() {
+    let mut rdr = get_reader("tests/data/cities_ok.csv").await.expect("Data file found");
+    let mut max_population = 0;
+    let mut max_record = None;
+    let mut records = rdr.records();
+    while let Some(record) = records.next().await {
+        let record = record.expect("Record read correctly");
+        if let Some(population) = record.get(3) {
+            let population = population.parse::<usize>()
+                .expect("Column 4 parsed as integer");
+            if population > max_population {
+                max_population = population;
+                max_record = Some(record.clone());
+            }
+        }
+    }
+    assert_eq!(max_record.expect("Max found").get(0), Some("Boston"));
+}
+
+#[helpers::test]
+async fn read_records_incomplete_row() {
+    let mut rdr = get_reader("tests/data/cities_incomplete_row.csv").await.expect("Data file found");
+    let mut read_correctly = 0;
+    let mut read_errors = Vec::new();
+    let mut records = rdr.records();
+    while let Some(record) = records.next().await {
+        match record {
+            Ok(_) => read_correctly += 1,
+            Err(e) => read_errors.push(e)
+        }
+    }
+    assert_eq!(read_correctly, 6);
+    assert_eq!(read_errors.len(), 1);
+    assert_eq!(
+        read_errors[0].to_string().as_str(), 
+        "CSV error: record 2 (line: 3, byte: 66): found record with 2 fields, but the previous record has 4 fields"
+    );
+    assert_eq!(
+        custom_error_message(&read_errors[0]).as_str(), 
+        "Unequal lengths: position = Some(Position { byte: 66, line: 3, record: 2 }), expected_len = 4, len = 2"
+    );
+}
+
+#[helpers::test]
+async fn read_records_non_utf8() {
+    let mut rdr = get_reader("tests/data/cities_pl_win1250.csv").await.expect("Data file found");
+    let mut read_correctly = 0;
+    let mut read_errors = Vec::new();
+    let mut records = rdr.records();
+    while let Some(record) = records.next().await {
+        match record {
+            Ok(_) => read_correctly += 1,
+            Err(e) => read_errors.push(e)
+        }
+    }
+    assert_eq!(read_correctly, 2);
+    assert_eq!(read_errors.len(), 5);
+    assert_eq!(
+        read_errors[0].to_string().as_str(), 
+        "CSV parse error: record 0 (line 1, field: 1, byte: 0): invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+    );
+    assert_eq!(
+        custom_error_message(&read_errors[0]).as_str(), 
+        "Invalid UTF8: position = Some(Position { byte: 0, line: 1, record: 0 }), err = invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+    );
+}

--- a/tests/read_records.rs
+++ b/tests/read_records.rs
@@ -35,13 +35,20 @@ async fn read_records_incomplete_row() {
     }
     assert_eq!(read_correctly, 6);
     assert_eq!(read_errors.len(), 1);
+    
+    // For file with unix newlines.
+    let (line, byte) = if cfg!(windows) {
+        (2, 67)
+    } else {
+        (3, 66) // correct value
+    };
     assert_eq!(
-        read_errors[0].to_string().as_str(), 
-        "CSV error: record 2 (line: 3, byte: 66): found record with 2 fields, but the previous record has 4 fields"
+        read_errors[0].to_string(), 
+        format!("CSV error: record 2 (line: {line}, byte: {byte}): found record with 2 fields, but the previous record has 4 fields")
     );
     assert_eq!(
-        custom_error_message(&read_errors[0]).as_str(), 
-        "Unequal lengths: position = Some(Position { byte: 66, line: 3, record: 2 }), expected_len = 4, len = 2"
+        custom_error_message(&read_errors[0]), 
+        format!("Unequal lengths: position = Some(Position {{ byte: {byte}, line: {line}, record: 2 }}), expected_len = 4, len = 2")
     );
 }
 

--- a/tests/read_serde.rs
+++ b/tests/read_serde.rs
@@ -44,13 +44,20 @@ async fn read_serde_incomplete_row() {
     }
     assert_eq!(read_correctly, 6);
     assert_eq!(read_errors.len(), 1);
+
+    // For file with unix newlines.
+    let (line, byte) = if cfg!(windows) {
+        (2, 67)
+    } else {
+        (3, 66) // correct value
+    };
     assert_eq!(
-        read_errors[0].to_string().as_str(), 
-        "CSV error: record 2 (line: 3, byte: 66): found record with 2 fields, but the previous record has 4 fields"
+        read_errors[0].to_string(), 
+        format!("CSV error: record 2 (line: {line}, byte: {byte}): found record with 2 fields, but the previous record has 4 fields")
     );
     assert_eq!(
-        custom_error_message(&read_errors[0]).as_str(), 
-        "Unequal lengths: position = Some(Position { byte: 66, line: 3, record: 2 }), expected_len = 4, len = 2"
+        custom_error_message(&read_errors[0]), 
+        format!("Unequal lengths: position = Some(Position {{ byte: {byte}, line: {line}, record: 2 }}), expected_len = 4, len = 2")
     );
 }
 
@@ -68,13 +75,16 @@ async fn read_serde_non_utf8() {
     }
     assert_eq!(read_correctly, 0);
     assert_eq!(read_errors.len(), 7);
+
+    // For file with unix newlines.
+    let line = if cfg!(windows) { 1 } else { 2 };
     assert_eq!(
         read_errors[0].to_string().as_str(), 
-        "CSV parse error: record 1 (line 2, field: 1, byte: 29): invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+        format!("CSV parse error: record 1 (line {line}, field: 1, byte: 29): invalid utf-8: invalid UTF-8 in field 1 near byte index 3")
     );
     assert_eq!(
         custom_error_message(&read_errors[0]).as_str(), 
-        "Invalid UTF8: position = Some(Position { byte: 29, line: 2, record: 1 }), err = invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+        format!("Invalid UTF8: position = Some(Position {{ byte: 29, line: {line}, record: 1 }}), err = invalid utf-8: invalid UTF-8 in field 1 near byte index 3")
     );
 }
 
@@ -92,12 +102,19 @@ async fn read_serde_non_int() {
     }
     assert_eq!(read_correctly, 6);
     assert_eq!(read_errors.len(), 1);
+
+    // For file with unix newlines.
+    let (line, byte) = if cfg!(windows) {
+        (3, 103)
+    } else {
+        (4, 101) // correct value
+    };
     assert_eq!(
         read_errors[0].to_string().as_str(), 
-        "CSV deserialize error: record 3 (line 4, byte: 101): field 4: invalid digit found in string"
+        format!("CSV deserialize error: record 3 (line {line}, byte: {byte}): field 4: invalid digit found in string")
     );
     assert_eq!(custom_error_message(
         &read_errors[0]).as_str(), 
-        "Deserialize error: position = Some(Position { byte: 101, line: 4, record: 3 }), field = Some(3): Error parsing integer: invalid digit found in string"
+        format!("Deserialize error: position = Some(Position {{ byte: {byte}, line: {line}, record: 3 }}), field = Some(3): Error parsing integer: invalid digit found in string")
     );
 }

--- a/tests/read_serde.rs
+++ b/tests/read_serde.rs
@@ -1,0 +1,103 @@
+#![cfg(feature = "with_serde")]
+
+use serde::Deserialize;
+
+mod helpers;
+use helpers::*;
+
+#[allow(dead_code)]
+#[derive(Deserialize, Clone)]
+struct City {
+    city: String,
+    region: String,
+    country: String,
+    population: usize,
+}
+
+#[helpers::test]
+async fn read_serde_ok() {
+    let des = get_deserializer("tests/data/cities_ok.csv").await.expect("Data file found");
+    let mut max_population = 0;
+    let mut max_record = None;
+    let mut records = des.into_deserialize::<City>();
+    while let Some(record) = records.next().await {
+        let record = record.expect("Record read correctly");
+        if record.population > max_population {
+            max_population = record.population;
+            max_record = Some(record.clone());
+        }
+    }
+    assert_eq!(&max_record.expect("Max found").city, "Boston");
+}
+
+#[helpers::test]
+async fn read_serde_incomplete_row() {
+    let des = get_deserializer("tests/data/cities_incomplete_row.csv").await.expect("Data file found");
+    let mut read_correctly = 0;
+    let mut read_errors = Vec::new();
+    let mut records = des.into_deserialize::<City>();
+    while let Some(record) = records.next().await {
+        match record {
+            Ok(_) => read_correctly += 1,
+            Err(e) => read_errors.push(e)
+        }
+    }
+    assert_eq!(read_correctly, 6);
+    assert_eq!(read_errors.len(), 1);
+    assert_eq!(
+        read_errors[0].to_string().as_str(), 
+        "CSV error: record 2 (line: 3, byte: 66): found record with 2 fields, but the previous record has 4 fields"
+    );
+    assert_eq!(
+        custom_error_message(&read_errors[0]).as_str(), 
+        "Unequal lengths: position = Some(Position { byte: 66, line: 3, record: 2 }), expected_len = 4, len = 2"
+    );
+}
+
+#[helpers::test]
+async fn read_serde_non_utf8() {
+    let des = get_deserializer("tests/data/cities_pl_win1250.csv").await.expect("Data file found");
+    let mut read_correctly = 0;
+    let mut read_errors = Vec::new();
+    let mut records = des.into_deserialize::<City>();
+    while let Some(record) = records.next().await {
+        match record {
+            Ok(_) => read_correctly += 1,
+            Err(e) => read_errors.push(e)
+        }
+    }
+    assert_eq!(read_correctly, 0);
+    assert_eq!(read_errors.len(), 7);
+    assert_eq!(
+        read_errors[0].to_string().as_str(), 
+        "CSV parse error: record 1 (line 2, field: 1, byte: 29): invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+    );
+    assert_eq!(
+        custom_error_message(&read_errors[0]).as_str(), 
+        "Invalid UTF8: position = Some(Position { byte: 29, line: 2, record: 1 }), err = invalid utf-8: invalid UTF-8 in field 1 near byte index 3"
+    );
+}
+
+#[helpers::test]
+async fn read_serde_non_int() {
+    let des = get_deserializer("tests/data/cities_non_int.csv").await.expect("Data file found");
+    let mut read_correctly = 0;
+    let mut read_errors = Vec::new();
+    let mut records = des.into_deserialize::<City>();
+    while let Some(record) = records.next().await {
+        match record {
+            Ok(_) => read_correctly += 1,
+            Err(e) => read_errors.push(e)
+        }
+    }
+    assert_eq!(read_correctly, 6);
+    assert_eq!(read_errors.len(), 1);
+    assert_eq!(
+        read_errors[0].to_string().as_str(), 
+        "CSV deserialize error: record 3 (line 4, byte: 101): field 4: invalid digit found in string"
+    );
+    assert_eq!(custom_error_message(
+        &read_errors[0]).as_str(), 
+        "Deserialize error: position = Some(Position { byte: 101, line: 4, record: 3 }), field = Some(3): Error parsing integer: invalid digit found in string"
+    );
+}


### PR DESCRIPTION
Added `DeserializeError` and `DeserializeErrorKind` to public interface in order to reveal more details about errors during serde de-serialization.

Bumped minimal Rust version to 1.60 due to dependence requirements (`bstr`).

Closes #16